### PR TITLE
update github actions trigger to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   deploy:
     name: Deploy project


### PR DESCRIPTION
Se ha cambiado la rama que lanza el github action de master a main para poder hacer el cambio de nombre de la rama en el repositorio.

A primera vista, no hace falta hacer más cambios, ya que los scripts de despliegue se lanzan localmente y no les afecta este cambio. En el caso del deploy se lanza directamente desde la rama main con el nuevo trigger por lo que se ejecutará correctamente.

#366 