### PR TITLE
Cambiar disposición de las etiquetas en la sección "Aprende"

### DIFF
--- a/apps/learn/templates/learn/index.html
+++ b/apps/learn/templates/learn/index.html
@@ -12,9 +12,9 @@
 
 <p>En esta sección podrás encontrar <strong>recursos de aprendizaje Python</strong>. Están clasificados por etiquetas:</p>
 
-<ul>
+<ul class="display: flex; flex-wrap: wrap">
   {% for label in labels %}
-    <li>
+    <li class="padding: 5px 5px 5px 0px">
         <a class="label"
            style="background-color: #{{ label.color }}; color: #{{ label.foreground_color }}"
            href="{% url "learn:resources_by_label" label=label %}">


### PR DESCRIPTION
¡Muy buenas!
Actualmente en la sección ["Aprende"](https://pythoncanarias.es/learn/) (adjunto imagen para dejar documentado cómo lo veo) hay una única columna de etiquetas (una lista) que, al menos en mi opinión, alarga mucho el alto de la página.

![Aprende-Python-Python-Canarias_](https://github.com/pythoncanarias/pycan-web/assets/8690921/d5403406-d034-4e1a-94bc-9cdcdc0e0498)

Mi sugerencia es cambiar esa disposición para que el contenido vaya fluyendo de una manera flexible. La manera de conseguirlo es utilizando `flex` y `flex-wrap`. En cuanto a cada elemento de la lista, admito no haber echado un vistazo al resto de la web para ver qué `padding` sería el más coherente, por lo que me he decantado por aplicar 5px generales y 0px a la izquierda.

Adjunto imagen de cómo quedaría:

![Aprende-Python-Python-Canarias](https://github.com/pythoncanarias/pycan-web/assets/8690921/df199171-eb66-480d-b9f4-edd97b2cf2fa)

¡Saludos!